### PR TITLE
Change backslashes to forward slashes, allow usage on unix systems

### DIFF
--- a/lib/icws/statistics/statisticcategory.rb
+++ b/lib/icws/statistics/statisticcategory.rb
@@ -1,4 +1,4 @@
-require '..\lib\statistics\statisticdefinition.rb'
+require '../lib/statistics/statisticdefinition.rb'
 
 class ICWS
     #Defines a category for supervisor statistics

--- a/lib/icws/statistics/statistics.rb
+++ b/lib/icws/statistics/statistics.rb
@@ -1,5 +1,5 @@
-require '..\lib\messages\messagesubscriber.rb'
-require '..\lib\statistics\statisticcategory.rb'
+require '../lib/messages/messagesubscriber.rb'
+require '../lib/statistics/statisticcategory.rb'
 
 class ICWS
     #Subscribes to Statistics from CIC

--- a/spec/test_script.rb
+++ b/spec/test_script.rb
@@ -1,10 +1,10 @@
-require '..\lib\connection.rb'
-require '..\lib\messages\messagequeue.rb'
-require '..\lib\statistics\statistics.rb'
-require '..\lib\status\status.rb'
-require '..\lib\configuration\users.rb'
-require '..\lib\configuration\workgroups.rb'
-require '..\lib\INTERNAL\challangemessagehandler.rb'
+require '../lib/connection.rb'
+require '../lib/messages/messagequeue.rb'
+require '../lib/statistics/statistics.rb'
+require '../lib/status/status.rb'
+require '../lib/configuration/users.rb'
+require '../lib/configuration/workgroups.rb'
+require '../lib/INTERNAL/challangemessagehandler.rb'
 
 
 def colorize(text, color_code)
@@ -24,7 +24,7 @@ connection = ICWS::Connection.new 'SalesforceProvisionService', 'http://Aeolus:8
 #connection = ICWS::Connection.new 'SalesforceProvisionService', 'http://morbo.dev2000.com:8018'
 
 puts connection.version.inspect
-puts connection.features.inspect 
+puts connection.features.inspect
 
 userId = 'aeolus_user'
 #userId = 'kevin.glinski'
@@ -47,10 +47,10 @@ def status_test(connection, userId)
   status = ICWS::Status.new connection
   statuses = status.all_system_statuses
   puts status.get_user_status userId
-  status.set_user_status userId, statuses[3].statusId 
+  status.set_user_status userId, statuses[3].statusId
   puts status.get_user_status userId
   status.set_user_status userId, statuses[4].statusId
-  
+
   puts status.allowable_statuses userId
 end
 
@@ -66,7 +66,7 @@ def configuration_test (connection)
     workgroup[:notes] = 'test notes'
     workgroups.update 'KPG', workgroup
     puts workgroups.get 'KPG', 'notes'
-    
+
     workgroups.delete 'KPG'
     puts workgroups.get_all
 end


### PR DESCRIPTION
Backslashes in requires cause the file loads to fail on Unix systems. Switch to forward slashes, Ruby should do the right thing on a Windows system.
